### PR TITLE
fix UCL compression tool

### DIFF
--- a/uuu.c
+++ b/uuu.c
@@ -7,6 +7,8 @@
 #define error(p,q,r)	printf(r)
 #endif
 
+#define BUFFSIZE_UCL 0x10000 //imagefs reserve 2 bytes for length of compressed block
+
 int main(int ac, char**av)
 {
     FILE *fpr, *fpw;
@@ -24,29 +26,43 @@ int main(int ac, char**av)
 
 	if(0 != fpr && 0 != fpw) {
 		unsigned int len = 0;
+		unsigned int unprocessed_len = 0;
 		ucl_uint	 out_len;
 		ucl_uint	 total_in_len = 0, total_out_len=0;
 		int			status;
-		unsigned char					buf[0x10000];
-		unsigned char 				out_buf[0x10000];
+		unsigned char in_buf[BUFFSIZE_UCL];
+		unsigned char out_buf[BUFFSIZE_UCL + (BUFFSIZE_UCL / 8 + 256)];
 		
 		for(;;) {
 			unsigned char packSize[2];
-			len = fread(buf, 1, sizeof(buf), fpr);
+			len = unprocessed_len = fread(in_buf, 1, sizeof(in_buf), fpr);
+			unsigned char* buf = in_buf;
 			total_in_len += len;
 			if(0 < len) {
-				printf("buf[0-4] = %02X %02X %02X %02X, Package %d bytes \n", buf[0], buf[1], buf[2], buf[3], len);
-				status = ucl_nrv2b_99_compress(buf, len, out_buf, &out_len, NULL, 9, NULL, NULL);//= ucl_nrv2b_decompress_8(buf, len, out_buf, &out_len, NULL);
-				if(status != 0) {
-					error(1, 0, "compression failure.\n");
-					break;
-				}
-				packSize[0] = (out_len >> 8) & 0xff;
-				packSize[1] = out_len & 0xff;
-				printf("out_len is %d (0x%02X 0x%02X)\n", out_len, packSize[0], packSize[1]);
-				if( 2 == fwrite(packSize, 1, 2, fpw)) {
-					total_out_len += (2 + fwrite(out_buf, 1, out_len, fpw));
-					printf("Write offset=%ld\n", ftell(fpw));
+				while(unprocessed_len != 0) {
+					printf("buf[0-4] = %02X %02X %02X %02X, Package %d bytes \n", buf[0], buf[1], buf[2], buf[3], len);
+					status = ucl_nrv2b_99_compress(buf, len, out_buf, &out_len, NULL, 9, NULL, NULL);//= ucl_nrv2b_decompress_8(buf, len, out_buf, &out_len, NULL);
+					if(status != 0) {
+						error(1, 0, "compression failure.\n");
+						return -1;
+					}
+					if(out_len >= BUFFSIZE_UCL) {
+						//Didn't compress, try smaller block value so we can use
+						//2 byte lengths in file
+						len -= 0x1000;
+						continue;
+					}
+
+					packSize[0] = (out_len >> 8) & 0xff;
+					packSize[1] = out_len & 0xff;
+					printf("out_len is %d (0x%02X 0x%02X)\n", out_len, packSize[0], packSize[1]);
+					if( 2 == fwrite(packSize, 1, 2, fpw)) {
+						total_out_len += (2 + fwrite(out_buf, 1, out_len, fpw));
+						printf("Write offset=%ld\n", ftell(fpw));
+					}
+					buf += len;
+					unprocessed_len -= len;
+					len = unprocessed_len;
 				}
 			}
 			else
@@ -57,4 +73,6 @@ int main(int ac, char**av)
 		printf("Total write %d bytes to output file: %s\n", total_out_len , av[2]);
 		printf("Done.\n");
 	}
+
+    return 0;
 }


### PR DESCRIPTION
Since there is a case when size of ucl compressed data can be larger than the uncompressed, we need to handle it to prevent imagefs block length overflow.

[Here is handling of that case in mkifs sources](https://github.com/vocho/openqnx/blob/cc95df3543a1c481d4f8ad387e29f0d1ff0c87fe/trunk/utils/m/mkxfs/mkxfs/mk_image_fsys.c#L382)